### PR TITLE
remove ssh debug flags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,12 +42,12 @@ resource "aws_instance" "f5_bigip" {
     host        = self.public_ip
   }
   provisioner "local-exec" {
-    command = "ssh -i ${var.ec2_private_key} -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o ConnectionAttempts=20 -v admin@${self.public_dns} 'modify auth user admin password \"${random_string.password.result}\"'"
+    command = "ssh -i ${var.ec2_private_key} -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o ConnectionAttempts=20 admin@${self.public_dns} 'modify auth user admin password \"${random_string.password.result}\"'"
   }
 
   # enable bash in order to use Terraform primitives
   provisioner "local-exec" {
-    command = "ssh -i ${var.ec2_private_key} -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o ConnectionAttempts=10 -v admin@${self.public_dns} 'modify auth user admin shell bash'"
+    command = "ssh -i ${var.ec2_private_key} -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o ConnectionAttempts=10 admin@${self.public_dns} 'modify auth user admin shell bash'"
   }
 
   #


### PR DESCRIPTION
there were flags set in local_execs that cause excessive debug logging during ssh sessions.